### PR TITLE
Added naive support for custom header mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,21 @@ res2: List[String] = List(name,address, "alice","wonderland")
 scala> CSVReader[Address].readCSVFromFileName("/tmp/example.csv", headers = Headers.ReadAndIgnore)
 res1: List[Address] = List(Address(alice,wonderland))
 ```
+
+An optional header -> field mapping can be provided when reading a CSV.
+
+```scala
+scala> import purecsv.safe._
+scala> case class Address(name: String, address: String)
+scala> val csv = """address,full name
+     | wonderland,alice""".stripMargin
+csv: String =
+address,full name
+wonderland,alice
+scala> CSVReader[Address].readCSVFromString(csv, headerMapping = Map("full name" -> "name"))
+res1: List[scala.util.Try[Address]] = List(Success(Address(alice,wonderland)))
+```
+
 ### Headers ###
 
 By default purecsv assumes that headers are present in csv that is being read (headers is set by default to Headers.ParseHeaders). 

--- a/src/main/scala/purecsv/safe/package.scala
+++ b/src/main/scala/purecsv/safe/package.scala
@@ -17,10 +17,10 @@ package purecsv
 import java.io.{File, Reader, StringReader}
 
 import purecsv.config.Headers.ParseHeaders
-import purecsv.config.{Headers, Trimming}
 import purecsv.config.Trimming.NoAction
-import purecsv.unsafe.{RecordSplitter, RecordSplitterImpl}
+import purecsv.config.{Headers, Trimming}
 import purecsv.safe.converter.{RawFieldsConverter, StringConverter}
+import purecsv.unsafe.{RecordSplitter, RecordSplitterImpl}
 import purecsv.util.ClassUtil.caseClassParams
 import purecsv.util.FileUtil
 import shapeless.{::, Generic, HList, HNil}
@@ -41,49 +41,57 @@ package object safe {
   implicit val shortc: StringConverter[Short] = purecsv.safe.converter.defaults.string.shortc
   implicit val stringc: StringConverter[String] = purecsv.safe.converter.defaults.string.stringc
 
-  implicit def optionc[A](implicit ac: StringConverter[A]): StringConverter[Option[A]] = purecsv.safe.converter.defaults.string.optionc
-
+  implicit def optionc[A](implicit ac: StringConverter[A]): StringConverter[Option[A]] =
+    purecsv.safe.converter.defaults.string.optionc
 
   // Raw Fields
   implicit val deriveHNil: RawFieldsConverter[HNil] = purecsv.safe.converter.defaults.rawfields.deriveHNil
 
   implicit def deriveHCons[V, T <: HList](implicit sc: StringConverter[V],
-                                          fto: RawFieldsConverter[T])
-  : RawFieldsConverter[V :: T] = {
+                                          fto: RawFieldsConverter[T]): RawFieldsConverter[V :: T] = {
     purecsv.safe.converter.defaults.rawfields.deriveHCons
   }
 
   implicit def deriveClass[A, R](implicit gen: Generic.Aux[A, R],
-                                 conv: RawFieldsConverter[R])
-  : RawFieldsConverter[A] = {
+                                 conv: RawFieldsConverter[R]): RawFieldsConverter[A] = {
     purecsv.safe.converter.defaults.rawfields.deriveClass
   }
 
   implicit class CSVRecord[A](a: A)(implicit rfc: RawFieldsConverter[A])
-    extends purecsv.csviterable.CSVRecord[A, RawFieldsConverter[A]](a)(rfc)
+      extends purecsv.csviterable.CSVRecord[A, RawFieldsConverter[A]](a)(rfc)
 
   implicit class CSVIterable[A](iter: Iterable[A])(implicit rfc: RawFieldsConverter[A])
-    extends purecsv.csviterable.CSVIterable[A, RawFieldsConverter[A]](iter)(rfc)
+      extends purecsv.csviterable.CSVIterable[A, RawFieldsConverter[A]](iter)(rfc)
 
   trait CSVReader[A] extends Serializable {
 
     def rfc: RawFieldsConverter[A]
 
-    def readCSVFromReader(r: Reader,
-                          delimiter: Char = RecordSplitter.defaultFieldSeparator,
-                          trimming: Trimming = NoAction,
-                          headers: Headers = ParseHeaders)(implicit typeTag: TypeTag[A]): Iterator[Try[A]] = {
-      RecordSplitterImpl.getRecords(r, caseClassParams[A], delimiter, trimming = trimming, headers = headers)
+    def readCSVFromReader(
+        r: Reader,
+        delimiter: Char = RecordSplitter.defaultFieldSeparator,
+        trimming: Trimming = NoAction,
+        headers: Headers = ParseHeaders,
+        headerMapping: Map[String, String] = Map.empty)(implicit typeTag: TypeTag[A]): Iterator[Try[A]] = {
+      RecordSplitterImpl
+        .getRecords(r,
+                    caseClassParams[A],
+                    delimiter,
+                    trimming = trimming,
+                    headers = headers,
+                    headerMapping = headerMapping)
         .map(record => rfc.tryFrom(record.toSeq))
     }
 
-    def readCSVFromString(s: String,
-                          delimiter: Char = RecordSplitter.defaultFieldSeparator,
-                          trimming: Trimming = NoAction,
-                          headers: Headers = ParseHeaders)(implicit typeTag: TypeTag[A]): List[Try[A]] = {
+    def readCSVFromString(
+        s: String,
+        delimiter: Char = RecordSplitter.defaultFieldSeparator,
+        trimming: Trimming = NoAction,
+        headers: Headers = ParseHeaders,
+        headerMapping: Map[String, String] = Map.empty)(implicit typeTag: TypeTag[A]): List[Try[A]] = {
       val r = new StringReader(s)
       try {
-        readCSVFromReader(r, delimiter, trimming, headers).toList
+        readCSVFromReader(r, delimiter, trimming, headers, headerMapping).toList
       } finally {
         r.close()
       }
@@ -92,20 +100,23 @@ package object safe {
     def readCSVFromFile(f: File,
                         delimiter: Char = RecordSplitter.defaultFieldSeparator,
                         trimming: Trimming = NoAction,
-                        headers: Headers = ParseHeaders)(implicit typeTag: TypeTag[A]): List[Try[A]] = {
+                        headers: Headers = ParseHeaders,
+                        headerMapping: Map[String, String] = Map.empty)(implicit typeTag: TypeTag[A]): List[Try[A]] = {
       val r = FileUtil.createReader(f)
       try {
-        readCSVFromReader(r, delimiter, trimming, headers).toList
+        readCSVFromReader(r, delimiter, trimming, headers, headerMapping).toList
       } finally {
         r.close()
       }
     }
 
-    def readCSVFromFileName(fileName: String,
-                            delimiter: Char = RecordSplitter.defaultFieldSeparator,
-                            trimming: Trimming = NoAction,
-                            headers: Headers = ParseHeaders)(implicit typeTag: TypeTag[A]): List[Try[A]] = {
-      readCSVFromFile(new File(fileName), delimiter, trimming, headers)
+    def readCSVFromFileName(
+        fileName: String,
+        delimiter: Char = RecordSplitter.defaultFieldSeparator,
+        trimming: Trimming = NoAction,
+        headers: Headers = ParseHeaders,
+        headerMapping: Map[String, String] = Map.empty)(implicit typeTag: TypeTag[A]): List[Try[A]] = {
+      readCSVFromFile(new File(fileName), delimiter, trimming, headers, headerMapping)
     }
 
   }

--- a/src/main/scala/purecsv/unsafe/RecordSplitter.scala
+++ b/src/main/scala/purecsv/unsafe/RecordSplitter.scala
@@ -17,7 +17,6 @@ package purecsv.unsafe
 import purecsv.config.Headers.ParseHeaders
 import purecsv.config.{Headers, Trimming}
 
-
 object RecordSplitter {
   val defaultFieldSeparator = ','
   val defaultFieldSeparatorStr = defaultFieldSeparator.toString
@@ -28,22 +27,25 @@ object RecordSplitter {
 trait RecordSplitter[R] {
 
   /** Split the input [[R]] into records, where each record is a sequence of raw fields */
-  def getRecords(r: R, fieldSep: Char,
+  def getRecords(r: R,
+                 fieldSep: Char,
                  quoteChar: Char,
                  headers: Headers,
                  trimming: Trimming,
-                 fields: Seq[String]): Iterator[Iterable[String]]
+                 fields: Seq[String],
+                 headerMapping: Map[String, String]): Iterator[Iterable[String]]
 
   /**
-   * Like [[getRecords(R, Char, Char, Int):Iterator[Iterable[String]]*]] but with all parameters except the first set
-   * to defaults and first line set to 0
-   */
+    * Like [[getRecords(R, Char, Char, Int):Iterator[Iterable[String]]*]] but with all parameters except the first set
+    * to defaults and first line set to 0
+    */
   def getRecords(r: R,
                  fields: Seq[String],
                  fieldSep: Char = RecordSplitter.defaultFieldSeparator,
                  quoteChar: Char = RecordSplitter.defaultQuoteChar,
                  headers: Headers = ParseHeaders,
-                 trimming: Trimming = Trimming.NoAction): Iterator[Iterable[String]] = {
-    getRecords(r, fieldSep, quoteChar, headers, trimming, fields)
+                 trimming: Trimming = Trimming.NoAction,
+                 headerMapping: Map[String, String] = Map.empty): Iterator[Iterable[String]] = {
+    getRecords(r, fieldSep, quoteChar, headers, trimming, fields, headerMapping)
   }
 }

--- a/src/test/scala/purecsv/safe/headersSuite.scala
+++ b/src/test/scala/purecsv/safe/headersSuite.scala
@@ -16,25 +16,40 @@ class headersSuite extends FunSuite with MustMatchers {
 
   test("should skip header and parse csv entry") {
     val csv = """id,name,email
-                |42,rachel,rachel@green.com""".stripMargin
+        |42,rachel,rachel@green.com""".stripMargin
 
     readCsv(csv, Headers.ReadAndIgnore) must contain only Success(TestUser(42, "rachel", Some("rachel@green.com")))
   }
 
   test("should parse csv entry with headers") {
     val csv = """id,name,email
-                |42,chandler,chandler@bing.com""".stripMargin
+        |42,chandler,chandler@bing.com""".stripMargin
 
     readCsv(csv, Headers.ParseHeaders) must contain only Success(TestUser(42, "chandler", Some("chandler@bing.com")))
   }
 
   test("should parse csv entry with headers even if fields order doesn't match class's fields order") {
     val csv = """email,id,name
-                |ross@geller.com,42,ross""".stripMargin
+        |ross@geller.com,42,ross""".stripMargin
 
     readCsv(csv, Headers.ParseHeaders) must contain only Success(TestUser(42, "ross", Some("ross@geller.com")))
   }
 
-  private def readCsv(csv: String, headers: Headers) =
-    CSVReader[TestUser].readCSVFromString(csv, headers = headers)
+  test("should parse csv entry with headers even if fields csv contains additional fields") {
+    val csv = """email,age,id,name
+        |ross@geller.com,34,42,ross""".stripMargin
+
+    readCsv(csv, Headers.ParseHeaders) must contain only Success(TestUser(42, "ross", Some("ross@geller.com")))
+  }
+
+  test("should parse csv entry with headers when mapping is provided for headers") {
+    val csv = """email address,age,id,name
+        |ross@geller.com,34,42,ross""".stripMargin
+
+    readCsv(csv, Headers.ParseHeaders, Map("email address" -> "email")) must contain only Success(
+      TestUser(42, "ross", Some("ross@geller.com")))
+  }
+
+  private def readCsv(csv: String, headers: Headers, headerMapping: Map[String, String] = Map.empty) =
+    CSVReader[TestUser].readCSVFromString(csv, headers = headers, headerMapping = headerMapping)
 }


### PR DESCRIPTION
I had the use case of a huge CSV file with with many columns that I don't care about but the column headers contain white space and special characters so that I need to provide a custom mapping to only select a few columns that I am interested in.

This is a very naive implementation but I couldn't come up with a fancier way. I could imaging something annotating case class fields with metadata for the csv column name but I wouldn't know how to achieve that.